### PR TITLE
Allow to pass baseurl of client instead of just the name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ env/
 .prevplaying
 .idea
 pseudo_schedule.xml
+venv

--- a/pseudo_config.py
+++ b/pseudo_config.py
@@ -37,6 +37,8 @@
 *
 * List of plex clients to use (add multiple clients to control multiple TV's)
 *
+Passing string with the client name or dict with the client base url :
+plexClients = [{'baseurl': 'http://rasplex.local:3005'}]
 '''
 plexClients = ['RasPlex']
 


### PR DESCRIPTION
Sometimes, Plex server don't see clients for some reasons...
But clients like "RasPlex" or still operational when talking to them directly.

This PR is about allowing user to set directly the url of the client instead of asking Plex server the list of available clients.

This allow to bypass Plex server when client is not showing up.

Disclaimer : This is only usefull when client can be controlled directly without passing via the Plex server proxy.